### PR TITLE
Demo session added

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 - [Awesome Speaker](#awesome-speaker)
     - [Presentation Editors](#presentation-editors)
     - [Source Code Tools](#source-code-tools)
-    - [Demo Tools](#demo-tools)
     - [Other Tools](#other-tools)
     - [Platforms](#platforms)
     - [Sharing Platforms](#sharing-platforms)
+    - [Learning Platforms](#learning-platforms)
     - [Blogs and Tutorials](#blogs-and-tutorials)
     - [Communities](#communities)    
 
@@ -29,13 +29,12 @@
 - [Code Surfer](https://github.com/pomber/code-surfer) - React component for scrolling, zooming and highlighting code.
 - [Terminalizer](https://terminalizer.com/) - Record your terminal and generate animated gif images or share a web player
 - [ttygif](https://github.com/icholy/ttygif) - Convert terminal recordings to animated gifs
-- [Katacoda](https://katacoda.com/) - Create online self-paced learning resources in virtual environment to test software. 
-- [Binder](https://mybinder.org/) - Transform a github repository into a set of interactive Jupyther Notebooks.
 - [Asciinema](https://asciinema.org/) - It helps to record terminal sessions and sharing them on the web without screen capture. 
 
 ## Other Tools
 *Other useful tools for presentations*
 - [Super Simple Highlighter](https://chrome.google.com/webstore/detail/super-simple-highlighter/hhlhjgianpocpoppaiihmlpgcoehlhio) - Adds highlights to text on web pages with this Chrome Extension, and tries to restore them on subsequent visits.
+- [Binder](https://mybinder.org/) - Transform a github repository into a set of interactive Jupyther Notebooks.
 
 ## Platforms
 *Conference Managers, Call for Speakers Managers, Ticket Managers, ...*
@@ -46,6 +45,9 @@
 - [SlideServe](https://www.slideserve.com) - Upload and Share Presentations Online.
 - [SlideShare](https://www.slideshare.net/) - Share what you know and love through presentations, infographics, documents and more.
 - [Speaker Deck](https://speakerdeck.com/) - Share presentations online. Simply upload your slides as a PDF, and we’ll turn them into a beautiful online experience.
+
+## Learning Platforms
+- [Katacoda](https://katacoda.com/) - Create online self-paced learning resources in virtual environment to test software. 
 
 ## Blogs and Tutorials
 *News, Tutorials, Tips & Tricks, Best Practices, ...*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
 - [Terminalizer](https://terminalizer.com/) - Record your terminal and generate animated gif images or share a web player
 - [ttygif](https://github.com/icholy/ttygif) - Convert terminal recordings to animated gifs
 
+## Demo Tools
+*Tools that can be used to show running software during a presentation* 
+- [Katacoda](https://katacoda.com/) - Create online self-paced learning resources in virtual environment to test software. 
+- [Binder](https://mybinder.org/) - Transform a github repository into a set of interactive Jupyther Notebooks.
+- [Asciinema](https://asciinema.org/) - It helps to record terminal sessions and sharing them on the web without screen capture. 
+
 ## Other Tools
 *Other useful tools for presentations*
 - [Super Simple Highlighter](https://chrome.google.com/webstore/detail/super-simple-highlighter/hhlhjgianpocpoppaiihmlpgcoehlhio) - Adds highlights to text on web pages with this Chrome Extension, and tries to restore them on subsequent visits.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Awesome Speaker](#awesome-speaker)
     - [Presentation Editors](#presentation-editors)
     - [Source Code Tools](#source-code-tools)
+    - [Demo Tools](#demo-tools)
     - [Other Tools](#other-tools)
     - [Platforms](#platforms)
     - [Sharing Platforms](#sharing-platforms)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@
 - [Code Surfer](https://github.com/pomber/code-surfer) - React component for scrolling, zooming and highlighting code.
 - [Terminalizer](https://terminalizer.com/) - Record your terminal and generate animated gif images or share a web player
 - [ttygif](https://github.com/icholy/ttygif) - Convert terminal recordings to animated gifs
-
-## Demo Tools
-*Tools that can be used to show running software during a presentation* 
 - [Katacoda](https://katacoda.com/) - Create online self-paced learning resources in virtual environment to test software. 
 - [Binder](https://mybinder.org/) - Transform a github repository into a set of interactive Jupyther Notebooks.
 - [Asciinema](https://asciinema.org/) - It helps to record terminal sessions and sharing them on the web without screen capture. 


### PR DESCRIPTION
I added a section to dial with the need, during presentation, to show some code running. For this purpose, I added katacoda, that is useful for self-paced learning session (it start on-the-fly a virtual machine with the intended environment and can let you advance to perform a demo);
asciinema is useful to record a terminal and show during a presentation avoiding problems due to different environment.
Finally binder is useful to show notebooks in general in session related to python / machine learning / data science presentation.