### PR TITLE
add presentation design prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Loom](https://www.loom.com) - Capture your screen, voice, and face and instantly share your video in less time than it would take to type an email.
 - [Mermaid](https://mermaid-js.github.io/mermaid/#/) - Create diagrams and visualizations using text and code.
 - [Photopea](https://photopea.com) - Advanced and free online photo editor.
+- [Presentation Design Prompts](https://github.com/SlideSpeak/presentation-design-prompts) - 56 open-source slide-design prompts for ChatGPT and Claude, each a full deck theme with a pinned color palette, fonts, and layout rules.
 - [Speaking Time Calculator](https://speakingtimecalculator.com) — Free tool that estimates speech duration from text speech with real-time updates, built-in speaking speed measurement, multi-section timing, and adjustable pause time.
 - [Super Simple Highlighter](https://chrome.google.com/webstore/detail/super-simple-highlighter/hhlhjgianpocpoppaiihmlpgcoehlhio) - Adds highlights to text on web pages with this Chrome Extension, and tries to restore them on subsequent visits.
 


### PR DESCRIPTION
Adding one to Other Tools.

This is an open-source, MIT-licensed collection of slide-design prompts for ChatGPT and Claude. Each entry is a prompt that carries a full design system: a color palette pinned to hex values, named Google Fonts, and layout rules. A speaker can paste one in, describe the talk, and get slides that look consistent instead of clip-art.

Repo: https://github.com/SlideSpeak/presentation-design-prompts

Kept it alphabetical in the section. I maintain the repo. Move or reword it if you prefer. Thanks!
